### PR TITLE
fix: allow users to set the physics client correctly

### DIFF
--- a/src/pybullet_planning/interfaces/control/control.py
+++ b/src/pybullet_planning/interfaces/control/control.py
@@ -2,7 +2,7 @@
 import numpy as np
 import pybullet as p
 
-from pybullet_planning.utils import CLIENT
+from pybullet_planning.utils import get_client
 from pybullet_planning.interfaces.env_manager.pose_transformation import unit_point
 from pybullet_planning.interfaces.robots.joint import get_max_velocity, get_max_force, get_joint_positions, get_movable_joints, \
     movable_from_joints
@@ -34,7 +34,7 @@ def control_joint(body, joint, value):
                                    targetVelocity=0.0,
                                    maxVelocity=get_max_velocity(body, joint),
                                    force=get_max_force(body, joint),
-                                   physicsClientId=CLIENT)
+                                   physicsClientId=get_client())
 
 def control_joints(body, joints, positions):
     """[summary]
@@ -62,7 +62,7 @@ def control_joints(body, joints, positions):
     return p.setJointMotorControlArray(body, joints, p.POSITION_CONTROL,
                                        targetPositions=positions,
                                        targetVelocities=[0.0] * len(joints),
-                                       physicsClientId=CLIENT) #,
+                                       physicsClientId=get_client()) #,
                                         #positionGains=[kp] * len(joints),
                                         #velocityGains=[kv] * len(joints),)
                                         #forces=forces)
@@ -112,7 +112,7 @@ def joint_controller_hold2(body, joints, positions, velocities=None,
                                     positionGains=[position_gain] * len(movable_joints),
                                     #velocityGains=[velocity_gain] * len(movable_joints),
                                     #forces=forces,
-                                    physicsClientId=CLIENT)
+                                    physicsClientId=get_client())
         yield current_conf
         current_conf = get_joint_positions(body, movable_joints)
 
@@ -136,7 +136,7 @@ def velocity_control_joints(body, joints, velocities):
     #kv = 0.3
     return p.setJointMotorControlArray(body, joints, p.VELOCITY_CONTROL,
                                        targetVelocities=velocities,
-                                       physicsClientId=CLIENT) #,
+                                       physicsClientId=get_client()) #,
                                         #velocityGains=[kv] * len(joints),)
                                         #forces=forces)
 
@@ -150,7 +150,7 @@ def compute_jacobian(robot, link, positions=None):
     velocities = [0.0] * len(positions)
     accelerations = [0.0] * len(positions)
     translate, rotate = p.calculateJacobian(robot, link, unit_point(), positions,
-                                            velocities, accelerations, physicsClientId=CLIENT)
+                                            velocities, accelerations, physicsClientId=get_client())
     #movable_from_joints(robot, joints)
     return list(zip(*translate)), list(zip(*rotate)) # len(joints) x 3
 

--- a/src/pybullet_planning/interfaces/debug_utils/debug_utils.py
+++ b/src/pybullet_planning/interfaces/debug_utils/debug_utils.py
@@ -3,7 +3,7 @@ import numpy as np
 import pybullet as p
 from itertools import product, combinations
 
-from pybullet_planning.utils import CLIENT, BASE_LINK, GREEN, RED, BLUE, BLACK, WHITE, NULL_ID, YELLOW
+from pybullet_planning.utils import get_client, BASE_LINK, GREEN, RED, BLUE, BLACK, WHITE, NULL_ID, YELLOW
 
 from pybullet_planning.interfaces.env_manager.pose_transformation import unit_pose, tform_point, unit_from_theta, get_distance
 from pybullet_planning.interfaces.geometry.bounding_box import get_aabb
@@ -24,7 +24,7 @@ def add_debug_parameter():
 def add_text(text, position=(0, 0, 0), color=BLACK, lifetime=None, parent=NULL_ID, parent_link=BASE_LINK):
     return p.addUserDebugText(str(text), textPosition=position, textColorRGB=color[:3], # textSize=1,
                               lifeTime=get_lifetime(lifetime), parentObjectUniqueId=parent, parentLinkIndex=parent_link,
-                              physicsClientId=CLIENT)
+                              physicsClientId=get_client())
 
 def add_line(start, end, color=BLACK, width=1, lifetime=None, parent=NULL_ID, parent_link=BASE_LINK):
     """[summary]
@@ -53,10 +53,10 @@ def add_line(start, end, color=BLACK, width=1, lifetime=None, parent=NULL_ID, pa
     """
     return p.addUserDebugLine(start, end, lineColorRGB=color[:3], lineWidth=width,
                               lifeTime=get_lifetime(lifetime), parentObjectUniqueId=parent, parentLinkIndex=parent_link,
-                              physicsClientId=CLIENT)
+                              physicsClientId=get_client())
 
 def remove_debug(debug):
-    p.removeUserDebugItem(debug, physicsClientId=CLIENT)
+    p.removeUserDebugItem(debug, physicsClientId=get_client())
 
 remove_handle = remove_debug
 
@@ -65,7 +65,7 @@ def remove_handles(handles):
         remove_debug(handle)
 
 def remove_all_debug():
-    p.removeAllUserDebugItems(physicsClientId=CLIENT)
+    p.removeAllUserDebugItems(physicsClientId=get_client())
 
 def add_body_name(body, name=None, **kwargs):
     from pybullet_planning.interfaces.env_manager.pose_transformation import set_pose
@@ -168,7 +168,7 @@ def draw_ray(ray, ray_result=None, visible_color=GREEN, occluded_color=RED, **kw
 
 
 def get_body_from_pb_id(i):
-    return p.getBodyUniqueId(i, physicsClientId=CLIENT)
+    return p.getBodyUniqueId(i, physicsClientId=get_client())
 
 def draw_collision_diagnosis(pb_closest_pt_output, viz_last_duration=-1, line_color=YELLOW, \
     focus_camera=True, camera_ray=np.array([0.1, 0, 0.05])):

--- a/src/pybullet_planning/interfaces/env_manager/pose_transformation.py
+++ b/src/pybullet_planning/interfaces/env_manager/pose_transformation.py
@@ -2,7 +2,7 @@ import math
 import numpy as np
 import pybullet as p
 
-from pybullet_planning.utils import CLIENT, unit_vector, quaternion_from_matrix, clip, euler_from_quaternion
+from pybullet_planning.utils import get_client, unit_vector, quaternion_from_matrix, clip, euler_from_quaternion
 
 #####################################
 # Geometry
@@ -146,7 +146,7 @@ def z_rotation(theta):
     return quat_from_euler([0, 0, theta])
 
 def matrix_from_quat(quat):
-    return np.array(p.getMatrixFromQuaternion(quat, physicsClientId=CLIENT)).reshape(3, 3)
+    return np.array(p.getMatrixFromQuaternion(quat, physicsClientId=get_client())).reshape(3, 3)
 
 def quat_from_matrix(mat):
     matrix = np.eye(4)
@@ -277,8 +277,8 @@ def apply_affine(affine, points):
 
 def set_pose(body, pose):
     (point, quat) = pose
-    p.resetBasePositionAndOrientation(body, point, quat, physicsClientId=CLIENT)
+    p.resetBasePositionAndOrientation(body, point, quat, physicsClientId=get_client())
 
 def get_pose(body):
-    return p.getBasePositionAndOrientation(body, physicsClientId=CLIENT)
+    return p.getBasePositionAndOrientation(body, physicsClientId=get_client())
     #return np.concatenate([point, quat])

--- a/src/pybullet_planning/interfaces/env_manager/savers.py
+++ b/src/pybullet_planning/interfaces/env_manager/savers.py
@@ -1,7 +1,7 @@
 import os
 import pybullet as p
 
-from pybullet_planning.utils import CLIENT, set_client
+from pybullet_planning.utils import get_client, set_client
 
 #####################################
 # Savers
@@ -18,7 +18,7 @@ class Saver(object):
 
 class ClientSaver(Saver):
     def __init__(self, new_client=None):
-        self.client = CLIENT
+        self.client = get_client()
         if new_client is not None:
             set_client(new_client)
 
@@ -38,7 +38,7 @@ class VideoSaver(Saver):
             assert ext == '.mp4'
             # STATE_LOGGING_PROFILE_TIMINGS, STATE_LOGGING_ALL_COMMANDS
             # p.submitProfileTiming("pythontest")
-            self.log_id = p.startStateLogging(p.STATE_LOGGING_VIDEO_MP4, fileName=path, physicsClientId=CLIENT)
+            self.log_id = p.startStateLogging(p.STATE_LOGGING_VIDEO_MP4, fileName=path, physicsClientId=get_client())
 
     def restore(self):
         if self.log_id is not None:

--- a/src/pybullet_planning/interfaces/env_manager/simulation.py
+++ b/src/pybullet_planning/interfaces/env_manager/simulation.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 import numpy as np
 import pybullet as p
 
-from pybullet_planning.utils import CLIENT, CLIENTS, GRAVITY, INFO_FROM_BODY, STATIC_MASS
+from pybullet_planning.utils import CLIENTS, GRAVITY, INFO_FROM_BODY, STATIC_MASS
 from pybullet_planning.utils import is_darwin, is_windows, get_client
 
 from pybullet_planning.interfaces.env_manager.savers import Saver
@@ -37,18 +37,18 @@ from pybullet_planning.interfaces.env_manager.shape_creation import ModelInfo, c
 
 
 def disable_viewer():
-    p.configureDebugVisualizer(p.COV_ENABLE_GUI, False, physicsClientId=CLIENT)
-    p.configureDebugVisualizer(p.COV_ENABLE_SEGMENTATION_MARK_PREVIEW, False, physicsClientId=CLIENT)
-    p.configureDebugVisualizer(p.COV_ENABLE_DEPTH_BUFFER_PREVIEW, False, physicsClientId=CLIENT)
-    p.configureDebugVisualizer(p.COV_ENABLE_RGB_BUFFER_PREVIEW, False, physicsClientId=CLIENT)
-    #p.configureDebugVisualizer(p.COV_ENABLE_RENDERING, False, physicsClientId=CLIENT)
-    #p.configureDebugVisualizer(p.COV_ENABLE_SINGLE_STEP_RENDERING, True, physicsClientId=CLIENT)
-    #p.configureDebugVisualizer(p.COV_ENABLE_SHADOWS, False, physicsClientId=CLIENT)
-    #p.configureDebugVisualizer(p.COV_ENABLE_WIREFRAME, True, physicsClientId=CLIENT)
+    p.configureDebugVisualizer(p.COV_ENABLE_GUI, False, physicsClientId=get_client())
+    p.configureDebugVisualizer(p.COV_ENABLE_SEGMENTATION_MARK_PREVIEW, False, physicsClientId=get_client())
+    p.configureDebugVisualizer(p.COV_ENABLE_DEPTH_BUFFER_PREVIEW, False, physicsClientId=get_client())
+    p.configureDebugVisualizer(p.COV_ENABLE_RGB_BUFFER_PREVIEW, False, physicsClientId=get_client())
+    #p.configureDebugVisualizer(p.COV_ENABLE_RENDERING, False, physicsClientId=get_client())
+    #p.configureDebugVisualizer(p.COV_ENABLE_SINGLE_STEP_RENDERING, True, physicsClientId=get_client())
+    #p.configureDebugVisualizer(p.COV_ENABLE_SHADOWS, False, physicsClientId=get_client())
+    #p.configureDebugVisualizer(p.COV_ENABLE_WIREFRAME, True, physicsClientId=get_client())
     #p.COV_ENABLE_MOUSE_PICKING, p.COV_ENABLE_KEYBOARD_SHORTCUTS
 
 def set_renderer(enable):
-    client = CLIENT
+    client = get_client()
     if not has_gui(client):
         return
     CLIENTS[client] = enable
@@ -57,7 +57,7 @@ def set_renderer(enable):
 class LockRenderer(Saver):
     # disabling rendering temporary makes adding objects faster
     def __init__(self, lock=True):
-        self.client = CLIENT
+        self.client = get_client()
         self.state = CLIENTS[self.client]
         # skip if the visualizer isn't active
         if has_gui(self.client) and lock:
@@ -125,14 +125,14 @@ def connect(use_gui=True, shadows=True, color=None, width=None, height=None):
 
 
 def disconnect():
-    # TODO: change CLIENT?
-    if CLIENT in CLIENTS:
-        del CLIENTS[CLIENT]
+    # TODO: change get_client()?
+    if get_client() in CLIENTS:
+        del CLIENTS[get_client()]
     with HideOutput():
-        return p.disconnect(physicsClientId=CLIENT)
+        return p.disconnect(physicsClientId=get_client())
 
 def is_connected():
-    return p.getConnectionInfo(physicsClientId=CLIENT)['isConnected']
+    return p.getConnectionInfo(physicsClientId=get_client())['isConnected']
 
 def get_connection(client=None):
     return p.getConnectionInfo(physicsClientId=get_client(client))['connectionMethod']
@@ -151,13 +151,13 @@ def add_data_path(data_path=None):
     return data_path
 
 def enable_gravity():
-    p.setGravity(0, 0, -GRAVITY, physicsClientId=CLIENT)
+    p.setGravity(0, 0, -GRAVITY, physicsClientId=get_client())
 
 def disable_gravity():
-    p.setGravity(0, 0, 0, physicsClientId=CLIENT)
+    p.setGravity(0, 0, 0, physicsClientId=get_client())
 
 def set_real_time(real_time):
-    p.setRealTimeSimulation(int(real_time), physicsClientId=CLIENT)
+    p.setRealTimeSimulation(int(real_time), physicsClientId=get_client())
 
 def enable_real_time():
     set_real_time(True)
@@ -184,7 +184,7 @@ def update_state():
 def reset_simulation():
     """resetSimulation will remove all objects from the world and reset the world to initial conditions.
     """
-    p.resetSimulation(physicsClientId=CLIENT)
+    p.resetSimulation(physicsClientId=get_client())
 
 #####################################
 
@@ -196,27 +196,27 @@ def load_pybullet(filename, fixed_base=False, scale=1., **kwargs):
         if filename.endswith('.urdf'):
             flags = get_urdf_flags(**kwargs)
             body = p.loadURDF(filename, useFixedBase=fixed_base, flags=flags,
-                              globalScaling=scale, physicsClientId=CLIENT)
+                              globalScaling=scale, physicsClientId=get_client())
         elif filename.endswith('.sdf'):
-            body = p.loadSDF(filename, physicsClientId=CLIENT)
+            body = p.loadSDF(filename, physicsClientId=get_client())
         elif filename.endswith('.xml'):
-            body = p.loadMJCF(filename, physicsClientId=CLIENT)
+            body = p.loadMJCF(filename, physicsClientId=get_client())
         elif filename.endswith('.bullet'):
-            body = p.loadBullet(filename, physicsClientId=CLIENT)
+            body = p.loadBullet(filename, physicsClientId=get_client())
         elif filename.endswith('.obj'):
             # TODO: fixed_base => mass = 0?
             body = create_obj(filename, scale=scale, **kwargs)
         else:
             raise ValueError(filename)
-    INFO_FROM_BODY[CLIENT, body] = ModelInfo(None, filename, fixed_base, scale)
+    INFO_FROM_BODY[get_client(), body] = ModelInfo(None, filename, fixed_base, scale)
     return body
 
 def set_caching(cache):
-    p.setPhysicsEngineParameter(enableFileCaching=int(cache), physicsClientId=CLIENT)
+    p.setPhysicsEngineParameter(enableFileCaching=int(cache), physicsClientId=get_client())
 
 def load_model_info(info):
     # TODO: disable file caching to reuse old filenames
-    # p.setPhysicsEngineParameter(enableFileCaching=0, physicsClientId=CLIENT)
+    # p.setPhysicsEngineParameter(enableFileCaching=0, physicsClientId=get_client())
     if info.path.endswith('.urdf'):
         return load_pybullet(info.path, fixed_base=info.fixed_base, scale=info.scale)
     if info.path.endswith('.obj'):
@@ -234,13 +234,13 @@ def get_model_path(rel_path): # TODO: add to search path
     return os.path.join(directory, '..', rel_path)
 
 def save_state():
-    return p.saveState(physicsClientId=CLIENT)
+    return p.saveState(physicsClientId=get_client())
 
 def restore_state(state_id):
-    p.restoreState(stateId=state_id, physicsClientId=CLIENT)
+    p.restoreState(stateId=state_id, physicsClientId=get_client())
 
 def save_bullet(filename):
-    p.saveBullet(filename, physicsClientId=CLIENT)
+    p.saveBullet(filename, physicsClientId=get_client())
 
 def restore_bullet(filename):
-    p.restoreState(fileName=filename, physicsClientId=CLIENT)
+    p.restoreState(fileName=filename, physicsClientId=get_client())

--- a/src/pybullet_planning/interfaces/env_manager/user_io.py
+++ b/src/pybullet_planning/interfaces/env_manager/user_io.py
@@ -5,8 +5,8 @@ import numpy as np
 import pybullet as p
 from collections import namedtuple
 
-from pybullet_planning.utils import INF, CLIENT, CLIENTS
-from pybullet_planning.utils import is_darwin
+from pybullet_planning.utils import INF, CLIENTS
+from pybullet_planning.utils import is_darwin, get_client
 
 # from future_builtins import map, filter
 # from builtins import input # TODO - use future
@@ -64,7 +64,7 @@ def elapsed_time(start_time):
 MouseEvent = namedtuple('MouseEvent', ['eventType', 'mousePosX', 'mousePosY', 'buttonIndex', 'buttonState'])
 
 def get_mouse_events():
-    return list(MouseEvent(*event) for event in p.getMouseEvents(physicsClientId=CLIENT))
+    return list(MouseEvent(*event) for event in p.getMouseEvents(physicsClientId=get_client()))
 
 def update_viewer():
     # https://docs.python.org/2/library/select.html
@@ -93,11 +93,11 @@ def simulate_for_duration(duration):
 def get_time_step():
     # {'gravityAccelerationX', 'useRealTimeSimulation', 'gravityAccelerationZ', 'numSolverIterations',
     # 'gravityAccelerationY', 'numSubSteps', 'fixedTimeStep'}
-    return p.getPhysicsEngineParameters(physicsClientId=CLIENT)['fixedTimeStep']
+    return p.getPhysicsEngineParameters(physicsClientId=get_client())['fixedTimeStep']
 
 
 def enable_separating_axis_test():
-    p.setPhysicsEngineParameter(enableSAT=1, physicsClientId=CLIENT)
+    p.setPhysicsEngineParameter(enableSAT=1, physicsClientId=get_client())
     #p.setCollisionFilterPair()
     #p.setCollisionFilterGroupMask()
     #p.setInternalSimFlags()
@@ -136,7 +136,7 @@ def wait_if_gui(*args, **kwargs):
 
 
 def is_unlocked():
-    return CLIENTS[CLIENT] is True
+    return CLIENTS[get_client()] is True
 
 
 def wait_if_unlocked(*args, **kwargs):
@@ -167,7 +167,7 @@ def step_simulation():
     Note: This also forces pybullet to update its bounding volume hierarchy. Ideally one would do this without calling
     the physics simulator. But this is the only workaround that we've found so far.
     """
-    p.stepSimulation(physicsClientId=CLIENT)
+    p.stepSimulation(physicsClientId=get_client())
 
 
 def threaded_input(*args, **kwargs):

--- a/src/pybullet_planning/interfaces/geometry/bounding_box.py
+++ b/src/pybullet_planning/interfaces/geometry/bounding_box.py
@@ -3,8 +3,8 @@ from collections import namedtuple
 from itertools import product
 import pybullet as p
 
-from pybullet_planning.utils import CLIENT, BASE_LINK, UNKNOWN_FILE, OBJ_MESH_CACHE
-from pybullet_planning.utils import implies
+from pybullet_planning.utils import BASE_LINK, UNKNOWN_FILE, OBJ_MESH_CACHE
+from pybullet_planning.utils import implies, get_client
 
 
 #####################################
@@ -46,11 +46,11 @@ def get_aabb(body, link=None):
     # (extra margin and extruded along the velocity vector).
     # Contact points with distance exceeding this threshold are not processed by the LCP solver.
     # AABBs are extended by this number. Defaults to 0.02 in Bullet 2.x
-    #p.setPhysicsEngineParameter(contactBreakingThreshold=0.0, physicsClientId=CLIENT)
+    #p.setPhysicsEngineParameter(contactBreakingThreshold=0.0, physicsClientId=get_client())
     if link is None:
         aabb = aabb_union(get_aabbs(body))
     else:
-        aabb = p.getAABB(body, linkIndex=link, physicsClientId=CLIENT)
+        aabb = p.getAABB(body, linkIndex=link, physicsClientId=get_client())
     return aabb
 
 get_lower_upper = get_aabb
@@ -113,7 +113,7 @@ def get_bodies_in_region(aabb):
     a list of object unique ids.
     """
     (lower, upper) = aabb
-    bodies = p.getOverlappingObjects(lower, upper, physicsClientId=CLIENT)
+    bodies = p.getOverlappingObjects(lower, upper, physicsClientId=get_client())
     return [] if bodies is None else bodies
 
 def get_aabb_volume(aabb):

--- a/src/pybullet_planning/interfaces/geometry/camera.py
+++ b/src/pybullet_planning/interfaces/geometry/camera.py
@@ -3,16 +3,16 @@ import numpy as np
 from collections import namedtuple
 import pybullet as p
 
-from pybullet_planning.utils import CLIENT
+from pybullet_planning.utils import get_client
 
 CameraInfo = namedtuple('CameraInfo', ['width', 'height', 'viewMatrix', 'projectionMatrix', 'cameraUp', 'cameraForward',
                                        'horizontal', 'vertical', 'yaw', 'pitch', 'dist', 'target'])
 
 def get_camera():
-    return CameraInfo(*p.getDebugVisualizerCamera(physicsClientId=CLIENT))
+    return CameraInfo(*p.getDebugVisualizerCamera(physicsClientId=get_client()))
 
 def set_camera(yaw, pitch, distance, target_position=np.zeros(3)):
-    p.resetDebugVisualizerCamera(distance, yaw, pitch, target_position, physicsClientId=CLIENT)
+    p.resetDebugVisualizerCamera(distance, yaw, pitch, target_position, physicsClientId=get_client())
 
 def get_pitch(point):
     dx, dy, dz = point
@@ -28,7 +28,7 @@ def set_camera_pose(camera_point, target_point=np.zeros(3)):
     yaw = get_yaw(delta_point) - np.pi/2 # TODO: hack
     pitch = get_pitch(delta_point)
     p.resetDebugVisualizerCamera(distance, math.degrees(yaw), math.degrees(pitch),
-                                 target_point, physicsClientId=CLIENT)
+                                 target_point, physicsClientId=get_client())
 
 def set_camera_pose2(world_from_camera, distance=2):
     from pybullet_planning.interfaces.env_manager.pose_transformation import tform_point, point_from_pose
@@ -39,7 +39,7 @@ def set_camera_pose2(world_from_camera, distance=2):
     #roll, pitch, yaw = euler_from_quat(quat_from_pose(world_from_camera))
     # TODO: assert that roll is about zero?
     #p.resetDebugVisualizerCamera(cameraDistance=distance, cameraYaw=math.degrees(yaw), cameraPitch=math.degrees(-pitch),
-    #                             cameraTargetPosition=target_world, physicsClientId=CLIENT)
+    #                             cameraTargetPosition=target_world, physicsClientId=get_client())
 
 CameraImage = namedtuple('CameraImage', ['rgbPixels', 'depthPixels', 'segmentationMaskBuffer'])
 
@@ -82,8 +82,8 @@ def get_projection_matrix(width, height, vertical_fov, near, far):
     aspect = float(width) / height
     fov_degrees = math.degrees(vertical_fov)
     projection_matrix = p.computeProjectionMatrixFOV(fov=fov_degrees, aspect=aspect,
-                                                     nearVal=near, farVal=far, physicsClientId=CLIENT)
-    # projection_matrix = p.computeProjectionMatrix(0, width, height, 0, near, far, physicsClientId=CLIENT)
+                                                     nearVal=near, farVal=far, physicsClientId=get_client())
+    # projection_matrix = p.computeProjectionMatrix(0, width, height, 0, near, far, physicsClientId=get_client())
     return projection_matrix
     #return np.reshape(projection_matrix, [4, 4])
 
@@ -110,7 +110,7 @@ def get_image(camera_pos, target_pos, width=640, height=480, vertical_fov=60.0, 
               segment=False, segment_links=False):
     # computeViewMatrixFromYawPitchRoll
     view_matrix = p.computeViewMatrix(cameraEyePosition=camera_pos, cameraTargetPosition=target_pos,
-                                      cameraUpVector=[0, 0, 1], physicsClientId=CLIENT)
+                                      cameraUpVector=[0, 0, 1], physicsClientId=get_client())
     projection_matrix = get_projection_matrix(width, height, vertical_fov, near, far)
     if segment:
         if segment_links:
@@ -124,7 +124,7 @@ def get_image(camera_pos, target_pos, width=640, height=480, vertical_fov=60.0, 
                                           shadow=False,
                                           flags=flags,
                                           renderer=p.ER_TINY_RENDERER, # p.ER_BULLET_HARDWARE_OPENGL
-                                          physicsClientId=CLIENT)[2:])
+                                          physicsClientId=get_client())[2:])
     depth = far * near / (far - (far - near) * image.depthPixels)
     # https://github.com/bulletphysics/bullet3/blob/master/examples/pybullet/examples/pointCloudFromCameraImage.py
     # https://github.com/bulletphysics/bullet3/blob/master/examples/pybullet/examples/getCameraImageTest.py

--- a/src/pybullet_planning/interfaces/kinematics/ik_utils.py
+++ b/src/pybullet_planning/interfaces/kinematics/ik_utils.py
@@ -2,7 +2,7 @@ import math
 import numpy as np
 import pybullet as p
 
-from pybullet_planning.utils import CLIENT
+from pybullet_planning.utils import get_client
 
 def inverse_kinematics_helper(robot, link, target_pose, null_space=None):
     (target_point, target_quat) = target_pose
@@ -14,15 +14,15 @@ def inverse_kinematics_helper(robot, link, target_pose, null_space=None):
 
             kinematic_conf = p.calculateInverseKinematics(robot, link, target_point,
                                                           lowerLimits=lower, upperLimits=upper, jointRanges=ranges, restPoses=rest,
-                                                          physicsClientId=CLIENT)
+                                                          physicsClientId=get_client())
         elif target_quat is None:
             #ikSolver = p.IK_DLS or p.IK_SDLS
             kinematic_conf = p.calculateInverseKinematics(robot, link, target_point,
                                                           #lowerLimits=ll, upperLimits=ul, jointRanges=jr, restPoses=rp, jointDamping=jd,
                                                           # solver=ikSolver, maxNumIterations=-1, residualThreshold=-1,
-                                                          physicsClientId=CLIENT)
+                                                          physicsClientId=get_client())
         else:
-            kinematic_conf = p.calculateInverseKinematics(robot, link, target_point, target_quat, physicsClientId=CLIENT)
+            kinematic_conf = p.calculateInverseKinematics(robot, link, target_point, target_quat, physicsClientId=get_client())
     except p.error as e:
         kinematic_conf = None
     if (kinematic_conf is None) or any(map(math.isnan, kinematic_conf)):

--- a/src/pybullet_planning/interfaces/robots/body.py
+++ b/src/pybullet_planning/interfaces/robots/body.py
@@ -2,7 +2,7 @@ import numpy as np
 from collections import namedtuple
 import pybullet as p
 
-from pybullet_planning.utils import CLIENT, INFO_FROM_BODY, STATIC_MASS, BASE_LINK, OBJ_MESH_CACHE, NULL_ID
+from pybullet_planning.utils import get_client, INFO_FROM_BODY, STATIC_MASS, BASE_LINK, OBJ_MESH_CACHE, NULL_ID
 from pybullet_planning.utils import implies
 from pybullet_planning.interfaces.env_manager.pose_transformation import Pose, Point, Euler
 from pybullet_planning.interfaces.env_manager.pose_transformation import euler_from_quat, base_values_from_pose, \
@@ -19,13 +19,13 @@ from pybullet_planning.interfaces.robots.link import get_links, parent_joint_fro
 # Bodies
 
 def get_bodies():
-    return [p.getBodyUniqueId(i, physicsClientId=CLIENT)
-            for i in range(p.getNumBodies(physicsClientId=CLIENT))]
+    return [p.getBodyUniqueId(i, physicsClientId=get_client())
+            for i in range(p.getNumBodies(physicsClientId=get_client()))]
 
 BodyInfo = namedtuple('BodyInfo', ['base_name', 'body_name'])
 
 def get_body_info(body):
-    return BodyInfo(*p.getBodyInfo(body, physicsClientId=CLIENT))
+    return BodyInfo(*p.getBodyInfo(body, physicsClientId=get_client()))
 
 def get_base_name(body):
     return get_body_info(body).base_name.decode(encoding='UTF-8')
@@ -55,9 +55,9 @@ def body_from_name(name):
     raise ValueError(name)
 
 def remove_body(body):
-    if (CLIENT, body) in INFO_FROM_BODY:
-        del INFO_FROM_BODY[CLIENT, body]
-    return p.removeBody(body, physicsClientId=CLIENT)
+    if (get_client(), body) in INFO_FROM_BODY:
+        del INFO_FROM_BODY[get_client(), body]
+    return p.removeBody(body, physicsClientId=get_client())
 
 def get_point(body):
     return get_pose(body)[0]
@@ -91,14 +91,14 @@ def set_base_values(body, values):
     set_quat(body, z_rotation(theta))
 
 def get_velocity(body):
-    linear, angular = p.getBaseVelocity(body, physicsClientId=CLIENT)
+    linear, angular = p.getBaseVelocity(body, physicsClientId=get_client())
     return linear, angular # [x,y,z], [wx,wy,wz]
 
 def set_velocity(body, linear=None, angular=None):
     if linear is not None:
-        p.resetBaseVelocity(body, linearVelocity=linear, physicsClientId=CLIENT)
+        p.resetBaseVelocity(body, linearVelocity=linear, physicsClientId=get_client())
     if angular is not None:
-        p.resetBaseVelocity(body, angularVelocity=angular, physicsClientId=CLIENT)
+        p.resetBaseVelocity(body, angularVelocity=angular, physicsClientId=get_client())
 
 def is_rigid_body(body):
     for joint in get_joints(body):
@@ -233,13 +233,13 @@ def set_color(body, color, link=BASE_LINK, shape_index=NULL_ID):
     # specularColor
     return p.changeVisualShape(body, link, shapeIndex=shape_index, rgbaColor=color,
                                #textureUniqueId=None, specularColor=None,
-                               physicsClientId=CLIENT)
+                               physicsClientId=get_client())
 
 def set_texture(body, texture=None, link=BASE_LINK, shape_index=NULL_ID):
     if texture is None:
         texture = NULL_ID
     return p.changeVisualShape(body, link, shapeIndex=shape_index, textureUniqueId=texture,
-                               physicsClientId=CLIENT)
+                               physicsClientId=get_client())
 
 def vertices_from_link(body, link):
     from pybullet_planning.interfaces.env_manager.shape_creation import vertices_from_data

--- a/src/pybullet_planning/interfaces/robots/collision.py
+++ b/src/pybullet_planning/interfaces/robots/collision.py
@@ -4,8 +4,7 @@ from itertools import product
 import numpy as np
 import pybullet as p
 
-from pybullet_planning.utils import CLIENT, BASE_LINK, MAX_DISTANCE, UNKNOWN_FILE
-from pybullet_planning.utils import get_client
+from pybullet_planning.utils import get_client, BASE_LINK, MAX_DISTANCE, UNKNOWN_FILE
 from pybullet_planning.interfaces.env_manager.user_io import step_simulation
 from pybullet_planning.interfaces.robots.body import get_all_links, get_bodies, get_links
 
@@ -20,7 +19,7 @@ def contact_collision():
         True if there is a collision, False otherwise
     """
     step_simulation()
-    return len(p.getContactPoints(physicsClientId=CLIENT)) != 0
+    return len(p.getContactPoints(physicsClientId=get_client())) != 0
 
 
 ContactResult = namedtuple('ContactResult', ['contactFlag', 'bodyUniqueIdA', 'bodyUniqueIdB',
@@ -86,7 +85,7 @@ def pairwise_link_collision_info(body1, link1, body2, link2=BASE_LINK, max_dista
     """
     return p.getClosestPoints(bodyA=body1, bodyB=body2, distance=max_distance,
                               linkIndexA=link1, linkIndexB=link2,
-                              physicsClientId=CLIENT)
+                              physicsClientId=get_client())
 
 def pairwise_link_collision(body1, link1, body2, link2=BASE_LINK, max_distance=MAX_DISTANCE):
     """check pairwise collision between bodies
@@ -228,7 +227,7 @@ def any_link_pair_collision_info(body1, links1, body2, links2=None, **kwargs):
 def body_collision_info(body1, body2, max_distance=MAX_DISTANCE): # 10000
     # TODO: confirm that this doesn't just check the base link
     return p.getClosestPoints(bodyA=body1, bodyB=body2, distance=max_distance,
-                              physicsClientId=CLIENT) # getContactPoints`
+                              physicsClientId=get_client()) # getContactPoints`
 
 def body_collision(body1, body2, max_distance=MAX_DISTANCE):
     return len(body_collision_info(body1, body2, max_distance)) != 0
@@ -517,7 +516,7 @@ def ray_collision(ray):
     # TODO: be careful to disable gravity and set static masses for everything
     step_simulation() # Needed for some reason
     start, end = ray
-    result, = p.rayTest(start, end, physicsClientId=CLIENT)
+    result, = p.rayTest(start, end, physicsClientId=get_client())
     # TODO: assign hit_position to be the end?
     return RayResult(*result)
 
@@ -533,4 +532,4 @@ def batch_ray_collision(rays, threads=1):
         numThreads=threads,
         #parentObjectUniqueId=
         #parentLinkIndex=
-        physicsClientId=CLIENT)]
+        physicsClientId=get_client())]

--- a/src/pybullet_planning/interfaces/robots/dynamics.py
+++ b/src/pybullet_planning/interfaces/robots/dynamics.py
@@ -4,7 +4,7 @@ from collections import defaultdict, deque, namedtuple
 import numpy as np
 import pybullet as p
 
-from pybullet_planning.utils import CLIENT, BASE_LINK, STATIC_MASS
+from pybullet_planning.utils import get_client, BASE_LINK, STATIC_MASS
 
 #####################################
 # https://docs.google.com/document/d/10sXEhzFRSnvFcl3XxNGhnD4N2SedqwdAvK3dsihxVUA/edit#
@@ -14,7 +14,7 @@ DynamicsInfo = namedtuple('DynamicsInfo', ['mass', 'lateral_friction',
                                            'contact_damping', 'contact_stiffness', 'body_type', 'collision_margin'])
 
 def get_dynamics_info(body, link=BASE_LINK):
-    return DynamicsInfo(*p.getDynamicsInfo(body, link, physicsClientId=CLIENT))
+    return DynamicsInfo(*p.getDynamicsInfo(body, link, physicsClientId=get_client()))
 
 get_link_info = get_dynamics_info
 
@@ -24,7 +24,7 @@ def get_mass(body, link=BASE_LINK):
 
 def set_dynamics(body, link=BASE_LINK, **kwargs):
     # TODO: iterate over all links
-    p.changeDynamics(body, link, physicsClientId=CLIENT, **kwargs)
+    p.changeDynamics(body, link, physicsClientId=get_client(), **kwargs)
 
 def set_mass(body, mass, link=BASE_LINK):
     set_dynamics(body, link=link, mass=mass)

--- a/src/pybullet_planning/interfaces/robots/joint.py
+++ b/src/pybullet_planning/interfaces/robots/joint.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 import pybullet as p
 
-from pybullet_planning.utils import CLIENT, CIRCULAR_LIMITS, UNBOUNDED_LIMITS, INF
+from pybullet_planning.utils import get_client, CIRCULAR_LIMITS, UNBOUNDED_LIMITS, INF
 
 #####################################
 # Joints
@@ -17,7 +17,7 @@ JOINT_TYPES = {
 }
 
 def get_num_joints(body):
-    return p.getNumJoints(body, physicsClientId=CLIENT)
+    return p.getNumJoints(body, physicsClientId=get_client())
 
 def get_joints(body):
     return list(range(get_num_joints(body)))
@@ -34,7 +34,7 @@ JointInfo = namedtuple('JointInfo', ['jointIndex', 'jointName', 'jointType',
                                      'parentFramePos', 'parentFrameOrn', 'parentIndex'])
 
 def get_joint_info(body, joint):
-    return JointInfo(*p.getJointInfo(body, joint, physicsClientId=CLIENT))
+    return JointInfo(*p.getJointInfo(body, joint, physicsClientId=get_client()))
 
 def get_joint_name(body, joint):
     return get_joint_info(body, joint).jointName # .decode('UTF-8')
@@ -63,7 +63,7 @@ JointState = namedtuple('JointState', ['jointPosition', 'jointVelocity',
                                        'jointReactionForces', 'appliedJointMotorTorque'])
 
 def get_joint_state(body, joint):
-    return JointState(*p.getJointState(body, joint, physicsClientId=CLIENT))
+    return JointState(*p.getJointState(body, joint, physicsClientId=get_client()))
 
 def get_joint_position(body, joint):
     return get_joint_state(body, joint).jointPosition
@@ -84,7 +84,7 @@ def get_joint_velocities(body, joints):
     return tuple(get_joint_velocity(body, joint) for joint in joints)
 
 def set_joint_position(body, joint, value):
-    p.resetJointState(body, joint, value, targetVelocity=0, physicsClientId=CLIENT)
+    p.resetJointState(body, joint, value, targetVelocity=0, physicsClientId=get_client())
 
 def set_joint_positions(body, joints, values):
     assert len(joints) == len(values)

--- a/src/pybullet_planning/interfaces/robots/link.py
+++ b/src/pybullet_planning/interfaces/robots/link.py
@@ -2,7 +2,7 @@ from itertools import product, combinations
 from collections import defaultdict, deque, namedtuple
 import pybullet as p
 
-from pybullet_planning.utils import BASE_LINK, CLIENT
+from pybullet_planning.utils import BASE_LINK, get_client
 from pybullet_planning.interfaces.robots.joint import get_num_joints, get_joints, get_joint_info, is_movable, prune_fixed_joints
 
 #####################################
@@ -58,7 +58,7 @@ def get_link_state(body, link, kinematics=True, velocity=True):
     # TODO: the defaults are set to False?
     # https://github.com/bulletphysics/bullet3/blob/master/examples/pybullet/pybullet.c
     return LinkState(*p.getLinkState(body, link, #computeLinkVelocity=velocity, computeForwardKinematics=kinematics,
-                                     physicsClientId=CLIENT))
+                                     physicsClientId=get_client()))
 
 def get_com_pose(body, link): # COM = center of mass
     link_state = get_link_state(body, link)

--- a/src/pybullet_planning/interfaces/task_modeling/constraint.py
+++ b/src/pybullet_planning/interfaces/task_modeling/constraint.py
@@ -2,7 +2,7 @@
 from collections import namedtuple
 import pybullet as p
 
-from pybullet_planning.utils import CLIENT, BASE_LINK
+from pybullet_planning.utils import get_client, BASE_LINK
 
 #####################################
 # Constraints - applies forces when not satisfied
@@ -12,11 +12,11 @@ def get_constraints():
     getConstraintUniqueId will take a serial index in range 0..getNumConstraints,  and reports the constraint unique id.
     Note that the constraint unique ids may not be contiguous, since you may remove constraints.
     """
-    return [p.getConstraintUniqueId(i, physicsClientId=CLIENT)
-            for i in range(p.getNumConstraints(physicsClientId=CLIENT))]
+    return [p.getConstraintUniqueId(i, physicsClientId=get_client())
+            for i in range(p.getNumConstraints(physicsClientId=get_client()))]
 
 def remove_constraint(constraint):
-    p.removeConstraint(constraint, physicsClientId=CLIENT)
+    p.removeConstraint(constraint, physicsClientId=get_client())
 
 ConstraintInfo = namedtuple('ConstraintInfo', ['parentBodyUniqueId', 'parentJointIndex',
                                                'childBodyUniqueId', 'childLinkIndex', 'constraintType',
@@ -25,7 +25,7 @@ ConstraintInfo = namedtuple('ConstraintInfo', ['parentBodyUniqueId', 'parentJoin
 
 def get_constraint_info(constraint): # getConstraintState
     # TODO: four additional arguments
-    return ConstraintInfo(*p.getConstraintInfo(constraint, physicsClientId=CLIENT)[:11])
+    return ConstraintInfo(*p.getConstraintInfo(constraint, physicsClientId=get_client())[:11])
 
 def get_fixed_constraints():
     fixed_constraints = []
@@ -60,9 +60,9 @@ def add_fixed_constraint(body, robot, robot_link, max_force=None):
                                     childFramePosition=unit_point(),
                                     parentFrameOrientation=quat,
                                     childFrameOrientation=unit_quat(),
-                                    physicsClientId=CLIENT)
+                                    physicsClientId=get_client())
     if max_force is not None:
-        p.changeConstraint(constraint, maxForce=max_force, physicsClientId=CLIENT)
+        p.changeConstraint(constraint, maxForce=max_force, physicsClientId=get_client())
     return constraint
 
 def remove_fixed_constraint(body, robot, robot_link):

--- a/src/pybullet_planning/interfaces/task_modeling/grasp.py
+++ b/src/pybullet_planning/interfaces/task_modeling/grasp.py
@@ -2,7 +2,6 @@ import warnings
 from collections import namedtuple
 import pybullet as p
 
-from pybullet_planning.utils import CLIENT, BASE_LINK
 from pybullet_planning.interfaces.env_manager.pose_transformation import multiply, invert, set_pose, get_pose
 from pybullet_planning.interfaces.robots.link import get_link_subtree, get_link_pose
 


### PR DESCRIPTION
Due to the importing of the module level CLIENT variable, the set_client functionality in shared_const.py does not work, meaning you are unable to set the client that the planning libraries operate on. This means you need to load the planning client first which is a pain and error prone.

I have updated all references of CLIENT to get_client() which gets the correct client from the shared_consts once set_client has been called.

Rather than passing in the physicsClientId to all the pybullet commands, it should instead use the [BulletClient](https://github.com/bulletphysics/bullet3/blob/master/examples/pybullet/gym/pybullet_utils/bullet_client.py) class which was designed specifcally for this purpose, but this would have been too drastic a change for this commit.